### PR TITLE
Update make watch to run changed test files first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ test: lint        ## Run tests and generate coverage report.
 
 .PHONY: watch
 watch:            ## Run tests on every change.
-	ls **/**.py | entr $(ENV_PREFIX)pytest -s -vvv -l --tb=long --maxfail=1 tests/
+	ls **/**.py | entr $(ENV_PREFIX)pytest --picked=first -s -vvv -l --tb=long --maxfail=1 tests/
 
 .PHONY: clean
 clean:            ## Clean unused files.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ codecov
 mypy
 gitchangelog
 mkdocs
+pytest-picked


### PR DESCRIPTION
add pytest-picked to run the changed tests first. this helps speed up TDD so that the changed tests run first and can fail early.

Fixes #19