### PR TITLE
[Bug] Fix hashing password

### DIFF
--- a/project_name/routes/user.py
+++ b/project_name/routes/user.py
@@ -9,12 +9,12 @@ from ..security import (
     AdminUser,
     AuthenticatedFreshUser,
     AuthenticatedUser,
-    HashedPassword,
     User,
     UserCreate,
     UserPasswordPatch,
     UserResponse,
     get_current_user,
+    get_password_hash,
 )
 
 router = APIRouter()
@@ -72,7 +72,7 @@ async def update_user_password(
         raise HTTPException(status_code=400, detail="Passwords don't match")
 
     # Update the password
-    user.password = HashedPassword(patch.password)
+    user.password = get_password_hash(patch.password)
 
     # Commit the session
     session.commit()


### PR DESCRIPTION
Use password hashing method instead of class because it'll return 500 ERROR from calling `/token` API if patching a user's password afterwards.

This change has tested in local development env.